### PR TITLE
Adds ros dependencies to requirements.

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -19,6 +19,7 @@ openssh-server
 python3
 python3-pip
 python3-setuptools
+ros-humble-andino-description
 software-properties-common
 sudo
 tmux


### PR DESCRIPTION
# 🎉 New feature

## Summary
- This dependency is installed during `rosdep install` command as suggested by the readme. However, adding the dependencies directly in the image is more straight forward so as to be able to omit the rosdep install command.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)

