### PR TITLE
Migrated simulation in Humble to Gazebo Harmonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## :clipboard: Description
 
-This package provides a simulation environment for [Andino](https://github.com/Ekumen-OS/andino) in [Gazebo Fortress](https://gazebosim.org/home) relying on [ros_gz](https://github.com/gazebosim/ros_gz) to integrate it with ROS 2.
+This package provides a simulation environment for [Andino](https://github.com/Ekumen-OS/andino) in [Gazebo Harmonic](https://gazebosim.org/home) relying on [ros_gz](https://github.com/gazebosim/ros_gz) to integrate it with ROS 2.
 
 ## :clamp: Platforms
 
@@ -13,7 +13,7 @@ This package provides a simulation environment for [Andino](https://github.com/E
 - OS:
   - Ubuntu 22.04 Jammy Jellyfish
 - Gazebo:
-  - Fortress
+  - Harmonic
 
 ## :inbox_tray: Installation
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To see a complete list of available arguments for the launch file do:
   ros2 launch andino_gz andino_gz.launch.py --show-args
   ```
 
-Make sure to review the required topics using `ign topics` and `ros2 topic` CLI tools.
+Make sure to review the required topics using `gz topic --list` and `ros2 topic` CLI tools.
 Also, consider using looking at the translation entries under `andino_gz/config/bridge_config.yaml`.
 
 ### :robot::robot::robot: Multi robot simulation
@@ -116,13 +116,13 @@ Also, consider using looking at the translation entries under `andino_gz/config/
     As before, you can launch as many robots as you want, for example launching two:
 
     ```sh
-    ros2 launch andino_gz andino_gz.launch.py nav2:=True robots:="andino1={x: 0.0, y: 0.0, z: 0.1, yaw: 0.};andino2={x: 1.0, y: 0.0, z: 0.1, yaw: 0.};" 
+    ros2 launch andino_gz andino_gz.launch.py nav2:=True robots:="andino1={x: 0.0, y: 0.0, z: 0.1, yaw: 0.};andino2={x: 1.0, y: 0.0, z: 0.1, yaw: 0.};"
     ```
 
     Once Gazebo window pops up, play the simulation using the gui.
 
 2. An RViz window will be spawned for each robot so it can be controlled independently. Use `2D Pose Estimate` to pass a hint to AMCL where is the initial point
-  
+
     Note you have to do it per robot, namely, per RViz window.
 
 

--- a/andino_gz/config_gui/default.config
+++ b/andino_gz/config_gui/default.config
@@ -31,11 +31,11 @@
 
 <!-- 3D scene -->
 <plugin filename="MinimalScene" name="3D View">
-  <ignition-gui>
+  <gz-gui>
     <title>3D View</title>
     <property type="bool" key="showTitleBar">false</property>
     <property type="string" key="state">docked</property>
-  </ignition-gui>
+  </gz-gui>
 
   <engine>ogre2</engine>
   <scene>scene</scene>
@@ -48,82 +48,82 @@
 
 <!-- Plugins that add functionality to the scene -->
 <plugin filename="EntityContextMenuPlugin" name="Entity context menu">
-  <ignition-gui>
+  <gz-gui>
     <property key="state" type="string">floating</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
     <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 <plugin filename="GzSceneManager" name="Scene Manager">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 <plugin filename="InteractiveViewControl" name="Interactive view control">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 <plugin filename="CameraTracking" name="Camera Tracking">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 <plugin filename="MarkerManager" name="Marker manager">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 <plugin filename="SelectEntities" name="Select Entities">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 
 <plugin filename="Spawn" name="Spawn Entities">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 
 <plugin filename="VisualizationCapabilities" name="Visualization Capabilities">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="width" type="double">5</property>
     <property key="height" type="double">5</property>
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 
 <!-- World control -->
 <plugin filename="WorldControl" name="World control">
-  <ignition-gui>
+  <gz-gui>
     <title>World control</title>
     <property type="bool" key="showTitleBar">false</property>
     <property type="bool" key="resizable">false</property>
@@ -136,7 +136,7 @@
       <line own="left" target="left"/>
       <line own="bottom" target="bottom"/>
     </anchors>
-  </ignition-gui>
+  </gz-gui>
 
   <play_pause>true</play_pause>
   <step>true</step>
@@ -147,7 +147,7 @@
 
 <!-- World statistics -->
 <plugin filename="WorldStats" name="World stats">
-  <ignition-gui>
+  <gz-gui>
     <title>World stats</title>
     <property type="bool" key="showTitleBar">false</property>
     <property type="bool" key="resizable">false</property>
@@ -160,7 +160,7 @@
       <line own="right" target="right"/>
       <line own="bottom" target="bottom"/>
     </anchors>
-  </ignition-gui>
+  </gz-gui>
 
   <sim_time>true</sim_time>
   <real_time>true</real_time>
@@ -170,7 +170,7 @@
 
 <!-- Insert simple shapes -->
 <plugin filename="Shapes" name="Shapes">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="x" type="double">0</property>
     <property key="y" type="double">0</property>
@@ -179,12 +179,12 @@
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
     <property key="cardBackground" type="string">#666666</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 
 <!-- Insert lights -->
 <plugin filename="Lights" name="Lights">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="x" type="double">250</property>
     <property key="y" type="double">0</property>
@@ -193,12 +193,12 @@
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
     <property key="cardBackground" type="string">#666666</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 
 <!-- Translate / rotate -->
 <plugin filename="TransformControl" name="Transform control">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="x" type="double">0</property>
     <property key="y" type="double">50</property>
@@ -207,7 +207,7 @@
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
     <property key="cardBackground" type="string">#777777</property>
-  </ignition-gui>
+  </gz-gui>
 
   <!-- disable legacy features used to connect this plugin to GzScene3D -->
   <legacy>false</legacy>
@@ -215,7 +215,7 @@
 
 <!-- Screenshot -->
 <plugin filename="Screenshot" name="Screenshot">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="x" type="double">250</property>
     <property key="y" type="double">50</property>
@@ -224,12 +224,12 @@
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
     <property key="cardBackground" type="string">#777777</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 
 <!-- Copy/Paste -->
 <plugin filename="CopyPaste" name="CopyPaste">
-  <ignition-gui>
+  <gz-gui>
     <property key="resizable" type="bool">false</property>
     <property key="x" type="double">300</property>
     <property key="y" type="double">50</property>
@@ -238,34 +238,34 @@
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
     <property key="cardBackground" type="string">#777777</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 
 <!-- Entity tree -->
 <plugin filename="EntityTree" name="Entity tree">
-  <ignition-gui>
+  <gz-gui>
     <property type="string" key="state">docked_collapsed</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 
 <!-- Inspector -->
 <plugin filename="ComponentInspector" name="Component inspector">
-  <ignition-gui>
+  <gz-gui>
     <property type="string" key="state">docked_collapsed</property>
-  </ignition-gui>
+  </gz-gui>
 </plugin>
 
 <!-- Teleop -->
 <plugin filename="Teleop" name="Teleop">
-    <ignition-gui>
+    <gz-gui>
         <property type="string" key="state">docked_collapsed</property>
-    </ignition-gui>
+    </gz-gui>
     <topic>/model/andino/cmd_vel</topic>
 </plugin>
 
 <!-- Image of the Camera display -->
 <plugin filename="ImageDisplay" name="Image Display">
-    <ignition-gui>
+    <gz-gui>
         <property key="state" type="string">docked_collapsed</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>

--- a/andino_gz/config_gui/default.config
+++ b/andino_gz/config_gui/default.config
@@ -128,7 +128,6 @@
     <property type="bool" key="showTitleBar">false</property>
     <property type="bool" key="resizable">false</property>
     <property type="double" key="height">72</property>
-    <property type="double" key="width">121</property>
     <property type="double" key="z">1</property>
 
     <property type="string" key="state">floating</property>
@@ -208,9 +207,6 @@
     <property key="showTitleBar" type="bool">false</property>
     <property key="cardBackground" type="string">#777777</property>
   </gz-gui>
-
-  <!-- disable legacy features used to connect this plugin to GzScene3D -->
-  <legacy>false</legacy>
 </plugin>
 
 <!-- Screenshot -->

--- a/andino_gz/env-hooks/andino_gz.dsv.in
+++ b/andino_gz/env-hooks/andino_gz.dsv.in
@@ -1,1 +1,1 @@
-prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share/@PROJECT_NAME@/models
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/@PROJECT_NAME@/models

--- a/andino_gz/env-hooks/andino_gz.sh.in
+++ b/andino_gz/env-hooks/andino_gz.sh.in
@@ -1,1 +1,1 @@
-ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"

--- a/andino_gz/launch/andino_gz.launch.py
+++ b/andino_gz/launch/andino_gz.launch.py
@@ -85,7 +85,7 @@ def generate_launch_description():
             Node(
                 package='ros_gz_bridge',
                 executable='parameter_bridge',
-                arguments=['/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock'],
+                arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
                 output='screen',
                 namespace='andino_gz_sim',
                 condition=IfCondition(ros_bridge),

--- a/andino_gz/package.xml
+++ b/andino_gz/package.xml
@@ -12,15 +12,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <!-- I didn't add 'gz-sim8' for Gazebo Harmonic as it can't get its keys resolved -->
   <exec_depend>andino_description</exec_depend>
   <exec_depend>andino_slam</exec_depend>
-
-  <exec_depend>ignition-gazebo6</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>
   <exec_depend>nav2_common</exec_depend>
   <exec_depend>ros_gz_bridge</exec_depend>
   <exec_depend>ros_gz_sim</exec_depend>
-
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/andino_gz/package.xml
+++ b/andino_gz/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <!-- I didn't add 'gz-sim8' for Gazebo Harmonic as it can't get its keys resolved -->
+  <!-- 'gz-sim8' for Gazebo Harmonic isn't added as it can't get its keys resolved -->
   <exec_depend>andino_description</exec_depend>
   <exec_depend>andino_slam</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>

--- a/andino_gz/urdf/andino_gz.urdf.xacro
+++ b/andino_gz/urdf/andino_gz.urdf.xacro
@@ -73,9 +73,6 @@
       <visualize>true</visualize>
       <update_rate>10.0</update_rate>
     </sensor>
-    <plugin name="gz::sim::systems::Sensors" filename="libgz-sim-sensors-system.so">
-      <render_engine>ogre2</render_engine>
-    </plugin>
   </gazebo>
 
   <gazebo reference="camera_link">

--- a/andino_gz/urdf/andino_gz.urdf.xacro
+++ b/andino_gz/urdf/andino_gz.urdf.xacro
@@ -5,14 +5,14 @@
 
   <gazebo>
     <plugin
-      filename="ignition-gazebo-diff-drive-system"
-      name="ignition::gazebo::systems::DiffDrive">
+      filename="gz-sim-diff-drive-system"
+      name="gz::sim::systems::DiffDrive">
       <left_joint>left_wheel_joint</left_joint>
       <right_joint>right_wheel_joint</right_joint>
       <wheel_separation>0.137</wheel_separation>
       <wheel_radius>0.033</wheel_radius>
       <!--
-      Odometry in the diff drive plugin is quite bad, therefore 
+      Odometry in the diff drive plugin is quite bad, therefore
       a dedicated OdometryPublisher plugin is being used.
       As it can not be disabled we publish odom info to an unused topic
       -->
@@ -27,8 +27,8 @@
   <!-- OdometryPublisher being used instead of Diff Drive's odometry -->
   <gazebo>
     <plugin
-      filename="ignition-gazebo-odometry-publisher-system"
-      name="ignition::gazebo::systems::OdometryPublisher">
+      filename="gz-sim-odometry-publisher-system"
+      name="gz::sim::systems::OdometryPublisher">
       <odom_publish_frequency>20</odom_publish_frequency>
       <robot_base_frame>base_link</robot_base_frame>
       <odom_frame>odom</odom_frame>
@@ -37,8 +37,8 @@
 
   <gazebo>
     <plugin
-      filename="ignition-gazebo-joint-state-publisher-system"
-      name="ignition::gazebo::systems::JointStatePublisher">
+      filename="gz-sim-joint-state-publisher-system"
+      name="gz::sim::systems::JointStatePublisher">
       <joint_name>left_wheel_joint</joint_name>
       <joint_name>right_wheel_joint</joint_name>
       <joint_name>caster_wheel_joint</joint_name>
@@ -73,7 +73,7 @@
       <visualize>true</visualize>
       <update_rate>10.0</update_rate>
     </sensor>
-    <plugin name="ignition::gazebo::systems::Sensors" filename="libignition-gazebo-sensors-system.so">
+    <plugin name="gz::sim::systems::Sensors" filename="libgz-sim-sensors-system.so">
       <render_engine>ogre2</render_engine>
     </plugin>
   </gazebo>

--- a/andino_gz/worlds/depot.sdf
+++ b/andino_gz/worlds/depot.sdf
@@ -6,11 +6,11 @@
       <max_step_size>0.01</max_step_size>
       <real_time_factor>1</real_time_factor>
     </physics>
-    <plugin name='ignition::gazebo::systems::Physics' filename='libignition-gazebo-physics-system.so'/>
-    <plugin name='ignition::gazebo::systems::UserCommands' filename='libignition-gazebo-user-commands-system.so'/>
-    <plugin name='ignition::gazebo::systems::SceneBroadcaster' filename='libignition-gazebo-scene-broadcaster-system.so'/>
-    <plugin name='ignition::gazebo::systems::Imu' filename='ignition-gazebo-imu-system'/>
-    <plugin name='ignition::gazebo::systems::Sensors' filename='ignition-gazebo-sensors-system'>
+    <plugin name='gz::sim::systems::Physics' filename='libgz-sim-physics-system.so'/>
+    <plugin name='gz::sim::systems::UserCommands' filename='libgz-sim-user-commands-system.so'/>
+    <plugin name='gz::sim::systems::SceneBroadcaster' filename='libgz-sim-scene-broadcaster-system.so'/>
+    <plugin name='gz::sim::systems::Imu' filename='gz-sim-imu-system'/>
+    <plugin name='gz::sim::systems::Sensors' filename='gz-sim-sensors-system'>
       <render_engine>ogre2</render_engine>
     </plugin>
     <scene>

--- a/andino_gz/worlds/empty.sdf
+++ b/andino_gz/worlds/empty.sdf
@@ -5,10 +5,10 @@
       <max_step_size>0.01</max_step_size>
       <real_time_factor>1</real_time_factor>
     </physics>
-    <plugin name='ignition::gazebo::systems::Physics' filename='libignition-gazebo-physics-system.so'/>
-    <plugin name='ignition::gazebo::systems::UserCommands' filename='libignition-gazebo-user-commands-system.so'/>
-    <plugin name='ignition::gazebo::systems::SceneBroadcaster' filename='libignition-gazebo-scene-broadcaster-system.so'/>
-    <plugin name="ignition::gazebo::systems::Sensors" filename="libignition-gazebo-sensors-system.so">
+    <plugin name='gz::sim::systems::Physics' filename='libgz-sim-physics-system.so'/>
+    <plugin name='gz::sim::systems::UserCommands' filename='libgz-sim-user-commands-system.so'/>
+    <plugin name='gz::sim::systems::SceneBroadcaster' filename='libgz-sim-scene-broadcaster-system.so'/>
+    <plugin name="gz::sim::systems::Sensors" filename="libgz-sim-sensors-system.so">
       <render_engine>ogre2</render_engine>
     </plugin>
 
@@ -23,11 +23,11 @@
 
       <!-- 3D scene -->
       <plugin filename="GzScene3D" name="3D View">
-        <ignition-gui>
+        <gz-gui>
           <title>3D View</title>
           <property type="bool" key="showTitleBar">false</property>
           <property type="string" key="state">docked</property>
-        </ignition-gui>
+        </gz-gui>
 
         <engine>ogre2</engine>
         <scene>scene</scene>
@@ -38,7 +38,7 @@
 
       <!-- Play / pause / step -->
       <plugin filename="WorldControl" name="World control">
-        <ignition-gui>
+        <gz-gui>
           <title>World control</title>
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
@@ -51,7 +51,7 @@
             <line own="left" target="left"/>
             <line own="bottom" target="bottom"/>
           </anchors>
-        </ignition-gui>
+        </gz-gui>
 
         <play_pause>true</play_pause>
         <step>true</step>
@@ -61,7 +61,7 @@
 
       <!-- Time / RTF -->
       <plugin filename="WorldStats" name="World stats">
-        <ignition-gui>
+        <gz-gui>
           <title>World stats</title>
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
@@ -74,7 +74,7 @@
             <line own="right" target="right"/>
             <line own="bottom" target="bottom"/>
           </anchors>
-        </ignition-gui>
+        </gz-gui>
 
         <sim_time>true</sim_time>
         <real_time>true</real_time>
@@ -85,7 +85,7 @@
 
       <!-- Insert simple shapes -->
       <plugin filename="Shapes" name="Shapes">
-        <ignition-gui>
+        <gz-gui>
           <property key="resizable" type="bool">false</property>
           <property key="x" type="double">0</property>
           <property key="y" type="double">0</property>
@@ -94,12 +94,12 @@
           <property key="state" type="string">floating</property>
           <property key="showTitleBar" type="bool">false</property>
           <property key="cardBackground" type="string">#666666</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
 
       <!-- Insert lights -->
       <plugin filename="Lights" name="Lights">
-        <ignition-gui>
+        <gz-gui>
           <property key="resizable" type="bool">false</property>
           <property key="x" type="double">250</property>
           <property key="y" type="double">0</property>
@@ -108,12 +108,12 @@
           <property key="state" type="string">floating</property>
           <property key="showTitleBar" type="bool">false</property>
           <property key="cardBackground" type="string">#666666</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
 
       <!-- Translate / rotate -->
       <plugin filename="TransformControl" name="Transform control">
-        <ignition-gui>
+        <gz-gui>
           <property key="resizable" type="bool">false</property>
           <property key="x" type="double">0</property>
           <property key="y" type="double">50</property>
@@ -122,12 +122,12 @@
           <property key="state" type="string">floating</property>
           <property key="showTitleBar" type="bool">false</property>
           <property key="cardBackground" type="string">#777777</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
 
       <!-- Screenshot -->
       <plugin filename="Screenshot" name="Screenshot">
-        <ignition-gui>
+        <gz-gui>
           <property key="resizable" type="bool">false</property>
           <property key="x" type="double">250</property>
           <property key="y" type="double">50</property>
@@ -136,36 +136,36 @@
           <property key="state" type="string">floating</property>
           <property key="showTitleBar" type="bool">false</property>
           <property key="cardBackground" type="string">#777777</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
 
       <!-- Entity tree -->
       <plugin filename="EntityTree" name="Entity tree">
-        <ignition-gui>
+        <gz-gui>
           <property type="string" key="state">docked_collapsed</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
 
       <!-- Inspector -->
       <plugin filename="ComponentInspector" name="Component inspector">
-        <ignition-gui>
+        <gz-gui>
           <property type="string" key="state">docked_collapsed</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
 
       <!-- Teleop -->
       <plugin filename="Teleop" name="Teleop">
-        <ignition-gui>
+        <gz-gui>
           <property type="string" key="state">docked_collapsed</property>
-        </ignition-gui>
+        </gz-gui>
         <topic>/model/andino/cmd_vel</topic>
       </plugin>
 
       <!-- Image of the Camera display -->
       <plugin filename="ImageDisplay" name="Image Display">
-        <ignition-gui>
+        <gz-gui>
           <property key="state" type="string">docked</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
 
     </gui>

--- a/andino_gz/worlds/office.sdf
+++ b/andino_gz/worlds/office.sdf
@@ -5,11 +5,11 @@
       <max_step_size>0.01</max_step_size>
       <real_time_factor>1</real_time_factor>
     </physics>
-    <plugin name='ignition::gazebo::systems::Physics' filename='libignition-gazebo-physics-system.so'/>
-    <plugin name='ignition::gazebo::systems::UserCommands' filename='libignition-gazebo-user-commands-system.so'/>
-    <plugin name='ignition::gazebo::systems::SceneBroadcaster' filename='libignition-gazebo-scene-broadcaster-system.so'/>
-    <plugin name='ignition::gazebo::systems::Imu' filename='ignition-gazebo-imu-system'/>
-    <plugin name='ignition::gazebo::systems::Sensors' filename='ignition-gazebo-sensors-system'>
+    <plugin name='gz::sim::systems::Physics' filename='libgz-sim-physics-system.so'/>
+    <plugin name='gz::sim::systems::UserCommands' filename='libgz-sim-user-commands-system.so'/>
+    <plugin name='gz::sim::systems::SceneBroadcaster' filename='libgz-sim-scene-broadcaster-system.so'/>
+    <plugin name='gz::sim::systems::Imu' filename='gz-sim-imu-system'/>
+    <plugin name='gz::sim::systems::Sensors' filename='gz-sim-sensors-system'>
       <render_engine>ogre2</render_engine>
     </plugin>
     <scene>

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -5,8 +5,8 @@ ARG USERID
 ARG USER
 
 # Setup environment
-ENV TERM linux
-ENV DEBIAN_FRONTEND noninteractive
+ENV TERM=linux
+ENV DEBIAN_FRONTEND=noninteractive
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Copy requirement files and install dependencies
@@ -14,18 +14,23 @@ COPY docker/requirements.txt .
 RUN apt-get update && apt-get install --no-install-recommends -y $(cat requirements.txt)
 RUN rm requirements.txt
 
-# Install Gazebo Fortress
-RUN sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-RUN wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-RUN sudo apt-get update
-RUN sudo apt-get install ignition-fortress -y
+# Add the Gazebo repository and install Gazebo Harmonic
+RUN sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" > /etc/apt/sources.list.d/gazebo-stable.list' && \
+    wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg && \
+    sudo apt update && \
+    sudo apt install -y gz-harmonic && \
+    sudo apt remove -y ros-humble-ros-gz* && \
+    sudo apt autoremove -y && \
+    sudo apt update && \
+    sudo apt install -y ros-humble-ros-gzharmonic && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 # Create a user with passwordless sudo
 RUN adduser --uid $USERID --gecos "ekumen developer" --disabled-password $USER
 RUN adduser $USER sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN echo "export QT_X11_NO_MITSHM=1" >> /home/$USER/.bashrc
-RUN echo "export IGN_IP=127.0.0.1" >> /home/$USER/.bashrc
+RUN echo "export GZ_IP=127.0.0.1" >> /home/$USER/.bashrc
 USER $USER
 
 # Adds USER to dialout and plugdev group.


### PR DESCRIPTION
# 🎉 New feature

Closes #72 

## Summary
The simulation on Humble has been changed and now uses Gazebo Harmonic instead of Gazebo Fortress.

**NOTE**: I didn't include the `gz-sim8` package on the package.xml because the rosdep keys for that package couldn't be found.

## Test it
Just compile the workspace and run the simulation as always. Check that it uses `Gazebo Harmonic` and that the LiDAR works well.

Here you can see a video of the simulation:

https://github.com/user-attachments/assets/be919b37-1c47-4a6b-8199-00f03caf6bbc


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)

