### PR TITLE
Fixes wrong command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _Note: You can use `--world_name` flag to indicate other [world](andino_gz/world
 By default the ros bridge and rviz are initialized. In case you prefer to disable any of those you can do it via its flags:
 
   ```sh
-  ros2 launch andino_gz andino_gz.launch.py ros_bridge:=false rviz:=false
+  ros2 launch andino_gz andino_gz.launch.py ros_bridge:=False rviz:=False
   ```
 
 To see a complete list of available arguments for the launch file do:


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a typo that happens to be a wrong command in the README


## Summary

It happens that the 2nd command the readme shows is
`ros2 launch andino_gz andino_gz.launch.py ros_bridge:=false rviz:=false`
Note how both arguments are in lower case. That's not an issue for the `ros_bridge` argument but it is for `rviz` see the screenshot below.

![image](https://github.com/user-attachments/assets/fc72a9db-9e83-4eec-8dff-b06d620974f3)

I didn't dig too deep but it seems when doing the list comprehension to call `PythonExpression` it expects `False` (as a valid python boolean) instead of `false` which is happening [here](https://github.com/Ekumen-OS/andino_gz/blob/humble/andino_gz/launch/andino_gz.launch.py#L141) and [there](https://github.com/Ekumen-OS/andino_gz/blob/humble/andino_gz/launch/andino_gz.launch.py#L153)

In the other hand `ros_bridge` is only used with `IfCondition`, [here](https://github.com/Ekumen-OS/andino_gz/blob/humble/andino_gz/launch/andino_gz.launch.py#L171). 
Nevertheless to maintain consistency and avoid having to set one argument in lower case and the other in upper case I changed both since `IfCondition` works both ways.

I can keep the changes only up to `rviz` arg if you prefer it.

- [x] Updated documentation (as needed)

