### PR TITLE
Use populated_office as default world and change map and README accor…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ source install/setup.bash
 
 ### Andino simulation
 
-<img src="./docs/media/andino_gz.png" width="800"/>
+<img src="./docs/media/populated_office_2.png" width="800"/>
 
 
 Once the package is built and sourced, you can start a simulation.
@@ -67,7 +67,7 @@ Once the package is built and sourced, you can start a simulation.
   ros2 launch andino_gz andino_gz.launch.py
   ```
 
-_Note: You can use `world_name` flag to indicate other [world](andino_gz/worlds/) to use. (For example: `depot.sdf`(default), `office.sdf`, `populated_office.sdf`, `empty.sdf`)_
+_Note: You can use `world_name` flag to indicate other [world](andino_gz/worlds/) to use. (For example: `populated_office.sdf`(default), `office.sdf`, `depot.sdf`, `empty.sdf`)_
 
 By default the ros bridge and rviz are initialized. In case you prefer to disable any of those you can do it via its flags:
 
@@ -82,10 +82,10 @@ To see a complete list of available arguments for the launch file do:
 
 Using a different world:
   ```sh
-  ros2 launch andino_gz andino_gz.launch.py world_name:=populated_office.sdf
+  ros2 launch andino_gz andino_gz.launch.py world_name:=depot.sdf
   ```
 
-<img src="./docs/media/populated_office_2.png" width="800"/>
+<img src="./docs/media/andino_gz.png" width="800"/>
 
 
 Make sure to review the required topics using `ign topics` and `ros2 topic` CLI tools.
@@ -145,15 +145,15 @@ Also, consider using looking at the translation entries under `andino_gz/config/
 
     **Important!**:
       -  When using `nav2` flag, the `map` must match the selected `world`. For example:
+         -  For `office.sdf` and `populated_office.sdf` worlds, the map need to be `office`:
+            ```
+            ros2 launch andino_gz andino_gz.launch.py nav2:=True world_name:=office.sdf map:=office
+            ```
          -  For `depot.sdf` world, the map need to be `depot`:
             ```
             ros2 launch andino_gz andino_gz.launch.py nav2:=True world_name:=depot.sdf map:=depot
             ```
             Typically, as this is the default world-map, there is no need to indicate them.
-         -  For `office.sdf` and `populated_office.sdf` worlds, the map need to be `office`:
-            ```
-            ros2 launch andino_gz andino_gz.launch.py nav2:=True world_name:=office.sdf map:=office
-            ```
 
 
 2. An RViz window will be spawned for each robot so it can be controlled independently. Use `2D Pose Estimate` to pass a hint to AMCL where is the initial point

--- a/andino_gz/launch/andino_gz.launch.py
+++ b/andino_gz/launch/andino_gz.launch.py
@@ -22,7 +22,7 @@ def generate_launch_description():
         'ros_bridge', default_value='True', description='Run ROS bridge node.')
     rviz_arg = DeclareLaunchArgument('rviz', default_value='True', description='Start RViz.')
     world_name_arg = DeclareLaunchArgument(
-        'world_name', default_value='depot.sdf', description='Name of the world to load. Match with map if using Nav2.')
+        'world_name', default_value='populated_office.sdf', description='Name of the world to load. Match with map if using Nav2.')
     robots_arg = DeclareLaunchArgument(
         'robots', default_value="andino={x: 0., y: 0., z: 0.1, yaw: 0.};",
         description='Robots to spawn, multiple robots can be stated separated by a ; ')
@@ -34,7 +34,7 @@ def generate_launch_description():
         'nav2', default_value='False',
         description='Enable Nav2 Bringup.')
     map_name_arg = DeclareLaunchArgument(
-      'map', default_value="depot", description='Name of the map to load. It should match the world_name.'
+      'map', default_value="office", description='Name of the map to load. It should match the world_name.'
     )
     params_file_arg = DeclareLaunchArgument(
         'params_file',


### PR DESCRIPTION
# 🎉 New feature

Closes [#88](https://github.com/Ekumen-OS/andino_gz/issues/88)

## Summary
Changed the default world to be populated_office. Rearranged a few screenshot images to match the default.

## Test it
With the new build from this change, I ran commands from README.md to check that the correct world is called and the navigation works correctly.

`ros2 launch andino_gz andino_gz.launch.py`
`ros2 launch andino_gz andino_gz.launch.py nav2:=True robots:="andino1={x: 0.0, y: 0.0, z: 0.1, yaw: 0.};andino2={x: 1.0, y: 0.0, z: 0.1, yaw: 0.};" `

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)

