### PR TITLE
Enable usage of custom world and map by arg and env

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Using a different world:
 
 <img src="./docs/media/populated_office_2.png" width="800"/>
 
+It is also possible to use a custom world and map by adding `worlds` and `maps` folder under `GZ_RESOURCE_PATH`.
+
+ ```sh
+  export GZ_RESOURCE_PATH='$HOME/gz_resource'
+  ros2 launch andino_gz andino_gz.launch.py world_name:=custom_world.sdf map:=custom_map
+  ```
 
 Make sure to review the required topics using `ign topics` and `ros2 topic` CLI tools.
 Also, consider using looking at the translation entries under `andino_gz/config/bridge_config.yaml`.

--- a/andino_gz/launch/andino_gz.launch.py
+++ b/andino_gz/launch/andino_gz.launch.py
@@ -17,6 +17,7 @@ from andino_gz.launch_tools.substitutions import TextJoin
 def generate_launch_description():
     pkg_andino_gz = get_package_share_directory('andino_gz')
     pkg_nav2_bringup = get_package_share_directory('nav2_bringup')
+    gz_resource_path = os.environ.get("GZ_RESOURCE_PATH", pkg_andino_gz)
 
     ros_bridge_arg = DeclareLaunchArgument(
         'ros_bridge', default_value='True', description='Run ROS bridge node.')
@@ -52,10 +53,10 @@ def generate_launch_description():
     params_file = LaunchConfiguration('params_file')
 
     # Obtains world path.
-    world_path = PathJoinSubstitution([pkg_andino_gz, 'worlds', world_name])
+    world_path = PathJoinSubstitution([gz_resource_path, 'worlds', world_name])
     log_world_path = LogInfo(msg=TextJoin(substitutions=["World path: ", world_path]))
     # Obtains the map path.
-    map_path = PathJoinSubstitution([pkg_andino_gz, 'maps', map_name, TextJoin(substitutions=[map_name ,'.yaml'])])
+    map_path = PathJoinSubstitution([gz_resource_path, 'maps', map_name, TextJoin(substitutions=[map_name ,'.yaml'])])
     log_map_path = LogInfo(msg=TextJoin(substitutions=["Map path: ", map_path]))
     # Gazebo arguments.
     gz_args = TextJoin(


### PR DESCRIPTION
# 🎉 New feature

Closes [#56](https://github.com/Ekumen-OS/andino_gz/issues/56)

## Summary
Allows user to pass custom world and map as launch arguments.
Took the alternative approach with GZ_RESOURCE_PATH.

## Test it
Copy worlds and maps data into a new location, and change file/folder names accordingly.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)

